### PR TITLE
Maintain position history

### DIFF
--- a/fa2/forceatlas2.py
+++ b/fa2/forceatlas2.py
@@ -63,6 +63,9 @@ class ForceAtlas2:
                  strongGravityMode=False,
                  gravity=1.0,
 
+                 # Random seed
+                 seed=None,
+
                  # Log
                  verbose=True):
         assert linLogMode == adjustSizes == multiThreaded == False, "You selected a feature that has not been implemented yet..."
@@ -77,11 +80,14 @@ class ForceAtlas2:
         self.strongGravityMode = strongGravityMode
         self.gravity = gravity
         self.verbose = verbose
+        self.seed = seed
 
     def init(self,
              G,  # a graph in 2D numpy ndarray format (or) scipy sparse matrix format
              pos=None  # Array of initial positions
              ):
+        print(self.seed)
+        random.seed(a=self.seed)
         isSparse = False
         if isinstance(G, numpy.ndarray):
             # Check our assumptions

--- a/fa2/forceatlas2.py
+++ b/fa2/forceatlas2.py
@@ -86,7 +86,6 @@ class ForceAtlas2:
              G,  # a graph in 2D numpy ndarray format (or) scipy sparse matrix format
              pos=None  # Array of initial positions
              ):
-        print(self.seed)
         random.seed(a=self.seed)
         isSparse = False
         if isinstance(G, numpy.ndarray):


### PR DESCRIPTION
This pull request adds the ability to maintain the position history while the ForceAtlas2 algorithm progresses (just within the NetworkX function, for now). This is useful if you want to create animations of the nodes from random to reaching their final resting positions.

By passing `keep_history=True`, it will return both the final positions, and a list of all the positions throughout the iterations.