### PR TITLE
fa2util: fix occasional zerodivisionerror

### DIFF
--- a/fa2/fa2util.py
+++ b/fa2/fa2util.py
@@ -279,7 +279,7 @@ def adjustSpeedAndApplyForces(nodes, speed, speedEfficiency, jitterTolerance):
     minSpeedEfficiency = 0.05
 
     # Protective against erratic behavior
-    if totalSwinging / totalEffectiveTraction > 2.0:
+    if totalEffectiveTraction and totalSwinging / totalEffectiveTraction > 2.0:
         if speedEfficiency > minSpeedEfficiency:
             speedEfficiency *= .5
         jt = max(jt, jitterTolerance)


### PR DESCRIPTION
This PR fixes the error raised [here](https://github.com/bhargavchippada/forceatlas2/issues/25)

Sometimes the totalEffectiveTraction vanishes which causes ZeroDivisionError, here I check it before dividing.