### PR TITLE
Fix AttributeError: Replace deprecated to_scipy_sparse_matrix with to_scipy_sparse_array

### DIFF
--- a/fa2/forceatlas2.py
+++ b/fa2/forceatlas2.py
@@ -245,7 +245,7 @@ class ForceAtlas2:
             or (cynetworkx and isinstance(G, cynetworkx.classes.graph.Graph))
         ), "Not a networkx graph"
         assert isinstance(pos, dict) or (pos is None), "pos must be specified as a dictionary, as in networkx"
-        M = networkx.to_scipy_sparse_matrix(G, dtype='f', format='lil', weight=weight_attr)
+        M = networkx.to_scipy_sparse_array(G, dtype='f', format='lil', weight=weight_attr) # Changed "to_scipy_sparse_array" to "to_scipy_sparse_array"
         if pos is None:
             l = self.forceatlas2(M, pos=None, iterations=iterations)
         else:


### PR DESCRIPTION
NetworkX 3.2+ removed `to_scipy_sparse_matrix()`, causing `fa2` to break.  
This commit replaces it with `to_scipy_sparse_array()`, restoring compatibility.